### PR TITLE
app & chart v0.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+venv/
+.DS_Store
+.idea/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.9.1-alpine
+
+RUN mkdir /app
+
+COPY app/ /app/
+
+WORKDIR /app
+
+RUN pip3 install -r requirements.txt
+
+ENV FLASK_APP=app.py
+
+USER 1000
+
+ENTRYPOINT ["python3", "-m", "flask", "run", "--host=0.0.0.0"]
+
+CMD ["--port=5000"]

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,53 @@
+from flask import Flask
+from flask import render_template
+import requests
+from json import JSONDecodeError
+from requests.exceptions import ConnectionError
+
+app = Flask(__name__)
+
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+
+@app.route('/products')
+def products():
+
+    source = 'https://reqres.in/api/products/'
+
+    try:
+        r = requests.get(source)
+    except ConnectionError as e:
+        error_message = f"Cannot reach products source '{source}'; {e}"
+        return render_template('products.html', error_message=error_message)
+
+    try:
+        r.json()
+    except JSONDecodeError:
+        error_message = f"Cannot list products - source '{source}' didn't return json."
+        app.logger.error(error_message)
+        return render_template('products.html', error_message=error_message)
+
+    try:
+        product_list = r.json()["data"]
+    except KeyError as e:
+        error_message = f"Cannot list products - '{e}' key not returned by '{source}', got: {r.json()}"
+        app.logger.error(error_message)
+        return render_template('products.html', error_message=error_message)
+
+    if product_list:
+        try:
+            product_list[0]["color"]
+            product_list[0]["name"]
+        except KeyError as e:
+            error_message = f"Cannot list products - '{e}' key not returned by '{source}', got: {r.json()}"
+            app.logger.error(error_message)
+            return render_template('products.html', error_message=error_message)
+
+    return render_template('products.html', product_list=product_list)
+
+
+if __name__ == '__main__':
+    app.run()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,2 @@
+flask==1.1.2
+requests==2.25.1

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>GET PRODUCTS</title>
+  <style>
+  .button {
+  background-color: #4CAF50;
+  border: none;
+  color: white;
+  padding: 15px 32px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  -webkit-transform: translate(-50%, -50%);
+  transform: translate(-50%, -50%);
+  }
+  </style>
+</head>
+<body>
+<button onclick="location.href='/products'" class="button">GET PRODUCTS</button>
+</body>
+</html>

--- a/app/templates/products.html
+++ b/app/templates/products.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>PRODUCTS</title>
+</head>
+<body>
+{% if error_message %}
+<p>{{error_message}}</p>
+{% else %}
+{% for product in product_list %}
+<div style="background-color: {{ product['color'] }} ; padding: 15px;">
+    <div style="display: inline-block; background-color: white; padding: 2px;">
+        <p style="font-family:verdana; padding: 4px;">{{ product["name"] }}</p>
+    </div>
+</div>
+<p></p>
+{% endfor %}
+{% endif %}
+</body>
+</html>

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: product-scraper
+version: 0.1.0
+description: A pod which scrapes a list of products and displays them in HTML

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: product-scraper
+    app.kubernetes.io/instance: product-scraper-{{ .Release.Name }}
+spec:
+  replicas: {{ .Values.deployment.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: product-scraper
+      app.kubernetes.io/instance: product-scraper-{{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: product-scraper
+        app.kubernetes.io/instance: product-scraper-{{ .Release.Name }}
+    spec:
+      containers:
+      - name: product-scraper
+        image: {{ .Values.deployment.image }}:{{ .Values.deployment.tag }}
+        args: ["--port={{ .Values.deployment.port }}"]
+        ports:
+          - containerPort: {{ .Values.deployment.port }}
+            name: http
+        resources:
+          limits:
+            cpu: {{ .Values.deployment.cpu_limit }}
+            memory: {{ .Values.deployment.memory_limit }}
+          requests:
+            cpu: {{ .Values.deployment.cpu_request }}
+            memory: {{ .Values.deployment.memory_request }}

--- a/chart/templates/hpa.yaml
+++ b/chart/templates/hpa.yaml
@@ -1,0 +1,24 @@
+apiVersion: autoscaling/v2beta2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ .Release.Name }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ .Release.Name }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+  - type: Resource
+    resource:
+      name: cpu
+      target:
+        type: Utilization
+        averageUtilization: {{ .Values.hpa.cpu_averageUtilization }}
+  - type: Resource
+    resource:
+      name: memory
+      target:
+        type: AverageValue
+        averageValue: {{ .Values.hpa.memory_averageValue }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app.kubernetes.io/name: product-scraper
+    app.kubernetes.io/instance: product-scraper-{{ .Release.Name }}
+spec:
+  ports:
+    - port: {{ .Values.deployment.port }}
+      name: http
+  selector:
+    app.kubernetes.io/instance: product-scraper-{{ .Release.Name }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,0 +1,15 @@
+deployment:
+  image: willemveerman/pstest
+  tag: latest
+  port: 5000
+  replicas: 1
+  memory_limit: 300Mi
+  memory_request: 100Mi
+  cpu_limit: 200m
+  cpu_request: 10m
+
+hpa:
+  minReplicas: 1
+  maxReplicas: 10
+  cpu_averageUtilization: 20
+  memory_averageValue: 25Mi

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,32 @@
+steps:
+- name: gcr.io/cloud-builders/docker
+  entrypoint: 'bash'
+  args: [ '-c', "chmod +x ./scripts/action.sh && ./scripts/action.sh --push" ]
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'REPO_NAME=$REPO_NAME'
+  - 'BRANCH_NAME=$BRANCH_NAME'
+  - 'TAG_NAME=$TAG_NAME'
+  - 'BASE_BRANCH=$_BASE_BRANCH'
+
+- name: "gcr.io/cloud-builders/git"
+  args: ["clone", "https://github.com/GoogleCloudPlatform/cloud-builders-community.git", "/workspace/__communitybuilders/"]
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--tag=gcr.io/$PROJECT_ID/helm:${_HELM_VERSION}', '--tag=gcr.io/$PROJECT_ID/helm:latest', '--build-arg', 'HELM_VERSION=v${_HELM_VERSION}', '/workspace/__communitybuilders/helm']
+
+- name: 'gcr.io/$PROJECT_ID/helm'
+  entrypoint: 'bash'
+  args: [ '-c', "chmod +x ./scripts/action.sh && ./scripts/action.sh --deploy" ]
+  env:
+  - 'PROJECT_ID=$PROJECT_ID'
+  - 'RELEASE_NAME=$REPO_NAME'
+  - 'BASE_BRANCH=$_BASE_BRANCH'
+  - 'CLOUDSDK_COMPUTE_ZONE=europe-west2-a'
+  - 'CLOUDSDK_CONTAINER_CLUSTER=my-first-cluster-1'
+  - 'DEPLOY_TO=test'
+  - 'TAG_NAME=$TAG_NAME'
+  - 'HELM_DEPLOY=FALSE'
+
+substitutions:
+  _HELM_VERSION: 3.4.2

--- a/environments/test.yaml
+++ b/environments/test.yaml
@@ -1,0 +1,6 @@
+namespace: default
+
+deployment:
+  image: gcr.io/pstest-302720/pstest
+  tag: 0.1.13
+

--- a/scripts/action.sh
+++ b/scripts/action.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+
+set +x
+set -e
+
+usage()
+{
+  echo "Usage: accepts one of the following parameters"
+  echo ""
+  echo "-p --push"
+  echo "-d --deploy"
+  echo "-r --rollback"
+  echo ""
+}
+
+
+case $1 in
+    -p | --push ) 
+
+      docker build -t gcr.io/$PROJECT_ID/$REPO_NAME .
+
+      if [[ -n "$TAG_NAME" ]]; then
+        docker tag gcr.io/$PROJECT_ID/$REPO_NAME gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME
+        docker push gcr.io/$PROJECT_ID/$REPO_NAME:$TAG_NAME
+      elif [[ "$BRANCH_NAME" == "master" ]]; then
+        docker push gcr.io/$PROJECT_ID/$REPO_NAME
+      else 
+        echo "Docker push only occurs on tag or push to master"
+      fi
+      ;;
+
+    -d | --deploy )
+
+      if [[ -n "$TAG_NAME" ]]; then
+        echo "Helm steps skipped on tag trigger"
+      else
+        helm template ./chart -f "environments/$DEPLOY_TO.yaml"
+
+        COMMIT_MSG=$(git log --oneline)
+        if [[ ${COMMIT_MSG:7:13} == " helm-deploy " ]]; then
+          DEPLOY_TO=$(echo $COMMIT_MSG | cut -d" " -f3)
+          HELM_DEPLOY="TRUE"
+        elif [[ "$BASE_BRANCH" == "master" && ${COMMIT_MSG:7:7} == " Merge " ]]; then
+          HELM_DEPLOY="TRUE"
+        else 
+          echo "Helm deploy only occurs on merge to master or commit message matching regex '^helm-deploy .*'"
+        fi
+
+        if [[ "$HELM_DEPLOY" == "TRUE" ]]; then
+          /builder/helm.bash upgrade $RELEASE_NAME ./chart -f "environments/$DEPLOY_TO.yaml" --install --debug
+        fi
+      fi
+      ;;
+
+    -r | --rollback )
+
+      /builder/helm.bash uninstall $RELEASE_NAME
+      ;;
+
+    -h | --help )
+
+      usage
+      ;;
+
+    * )                     
+    
+      usage
+      echo "You supplied '$1'"
+      exit 1
+      ;;
+esac

--- a/scripts/test_hpa.sh
+++ b/scripts/test_hpa.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+INITIAL_PODS=$(kubectl get pods --no-headers | wc -l)
+
+kubectl port-forward svc/pstest 5000:5000 &
+
+sleep 3
+
+for i in {1..150}
+do
+  curl localhost:5000/products
+  echo ""
+  echo ""
+  echo "-----"
+  echo "$i"
+  sleep 0.1
+done
+
+pkill kubectl -9
+
+FINAL_PODS=$(kubectl get pods --no-headers | wc -l)
+
+echo ""
+echo "-----"
+echo "-----"
+echo "-----"
+echo ""
+echo "INITIAL: $INITIAL_PODS"
+echo "FINAL: $FINAL_PODS"
+


### PR DESCRIPTION
- Cloud Build does not support triggering a build upon PR/MR merge, so instead I created a script which is triggered by `tag` and all `push` operations - if the push comprises a merge to master then the image will be built and the chart deployed to a test environment.
   - This enables standard CI workflow: pushes trigger an image build and chart validation; `tag`, or `push` to master, triggers image push to container registry and chart deployment
- In order to support GitOps workflow, deployment to a specific environment can also be triggered via a formatted commit message
- Docker builds and chart deployments can also be carried out using `gcloud` CLI with substitutions
- To test HPA:
   1. Deploy the chart, wait for ~ 1 minute until pods reach a steady state
   2. Locally, run `./scripts/test_hpa.sh` and observe that the pods will be scaled out.
